### PR TITLE
모두의 말뭉치 loader classes 를 Korpora 에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 dist/
 build/
 *.egg-info/
+*.pyc
 
 # Develop
 tmp/

--- a/Korpora/korpus_korsts.py
+++ b/Korpora/korpus_korsts.py
@@ -86,7 +86,6 @@ class KorSTSKorpus(Korpus):
 
         if root_dir is None:
             root_dir = default_korpora_path
-
         fetch_korsts(root_dir, force_download)
 
         for info in KORSTS_FETCH_INFORMATION:

--- a/Korpora/korpus_modu_messenger.py
+++ b/Korpora/korpus_modu_messenger.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuMessengerKorpus(Korpus):
@@ -81,10 +66,3 @@ def load_modu_messenger(paths):
         documents = data['document']
         utterances += [document_to_utterance(doc) for doc in documents]
     return utterances
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/korpus_modu_messenger.py
+++ b/Korpora/korpus_modu_messenger.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuMessengerKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuMessengerKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_MESSENGER')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_메신저_말뭉치(conversation).train', load_modu_messenger(paths))
 

--- a/Korpora/korpus_modu_morpheme.py
+++ b/Korpora/korpus_modu_morpheme.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List, Tuple
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuMorphemeKorpus(Korpus):
@@ -147,10 +132,3 @@ def load_modu_morpheme(paths):
         documents_iterator = tqdm(documents, desc=desc, total=len(documents))
         examples += [example for doc in documents_iterator for example in document_to_examples(doc)]
     return examples
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/korpus_modu_morpheme.py
+++ b/Korpora/korpus_modu_morpheme.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List, Tuple
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuMorphemeKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuMorphemeKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_MP')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_형태분석_말뭉치.train', load_modu_morpheme(paths))
         self.tagmap = {

--- a/Korpora/korpus_modu_ne.py
+++ b/Korpora/korpus_modu_ne.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List, Tuple
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuNEKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuNEKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_NE')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_개체명_말뭉치.train', load_modu_ne(paths))
         self.tagmap = {

--- a/Korpora/korpus_modu_ne.py
+++ b/Korpora/korpus_modu_ne.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List, Tuple
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuNEKorpus(Korpus):
@@ -108,10 +93,3 @@ def load_modu_ne(paths):
         documents_iterator = tqdm(documents, desc=desc, total=len(documents))
         examples += [example for doc in documents_iterator for example in document_to_examples(doc)]
     return examples
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/korpus_modu_news.py
+++ b/Korpora/korpus_modu_news.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List
-from Korpora.korpora import Korpus, KorpusData
 
+from .korpora import Korpus, KorpusData
+from .utils import default_korpora_path
 
 description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
     총 13 개의 말뭉치로 이뤄져 있습니다.
@@ -37,8 +38,10 @@ class ModuKorpus(Korpus):
 
 
 class ModuNewsKorpus(ModuKorpus):
-    def __init__(self, root_dir_or_paths, force_download=False, load_light=True):
+    def __init__(self, root_dir_or_paths=None, force_download=False, load_light=True):
         super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_NEWSPAPER')
         paths = find_corpus_paths(root_dir_or_paths)
         if load_light:
             self.train = ModuNewsDataLight('모두의_뉴스_말뭉치(light).train', load_modu_news(paths, load_light))

--- a/Korpora/korpus_modu_news.py
+++ b/Korpora/korpus_modu_news.py
@@ -162,7 +162,7 @@ def load_modu_news(paths, load_light):
     return news
 
 
-def fetch_modu():
+def fetch_modu(root_dir=None, force_download=False):
     raise NotImplementedError(
         "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
         "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"

--- a/Korpora/korpus_modu_news.py
+++ b/Korpora/korpus_modu_news.py
@@ -31,9 +31,14 @@ license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광�
     정확한 라이센스는 확인 중 입니다."""
 
 
-class ModuNewsKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, load_light=True, force_download=False):
+class ModuKorpus(Korpus):
+    def __init__(self):
         super().__init__(description, license)
+
+
+class ModuNewsKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths, force_download=False, load_light=True):
+        super().__init__()
         paths = find_corpus_paths(root_dir_or_paths)
         if load_light:
             self.train = ModuNewsDataLight('모두의_뉴스_말뭉치(light).train', load_modu_news(paths, load_light))

--- a/Korpora/korpus_modu_news.py
+++ b/Korpora/korpus_modu_news.py
@@ -33,13 +33,15 @@ license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광�
 
 
 class ModuKorpus(Korpus):
-    def __init__(self):
+    def __init__(self, force_download=False):
+        if force_download:
+            fetch_modu()
         super().__init__(description, license)
 
 
 class ModuNewsKorpus(ModuKorpus):
     def __init__(self, root_dir_or_paths=None, force_download=False, load_light=True):
-        super().__init__()
+        super().__init__(force_download)
         if root_dir_or_paths is None:
             root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_NEWSPAPER')
         paths = find_corpus_paths(root_dir_or_paths)

--- a/Korpora/korpus_modu_spoken.py
+++ b/Korpora/korpus_modu_spoken.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuSpokenKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuSpokenKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_SPOKEN')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_구어_말뭉치.train', load_modu_spoken(paths))
 
@@ -38,10 +41,14 @@ def find_corpus_paths(root_dir_or_paths):
 def load_modu_spoken(paths):
     texts = []
     for i_path, path in enumerate(tqdm(paths, desc='Loading Spoken', total=len(paths))):
-        with open(path, encoding='utf-8') as f:
-            data = json.load(f)
-        documents = data['document']
-        texts += [paragraph for document in documents for paragraph in document_to_texts(document)]
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = json.load(f)
+            documents = data['document']
+            texts += [paragraph for document in documents for paragraph in document_to_texts(document)]
+        except:
+            print(f'Found erorrs in {path} Skip it')
+            continue
     return texts
 
 

--- a/Korpora/korpus_modu_spoken.py
+++ b/Korpora/korpus_modu_spoken.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuSpokenKorpus(Korpus):
@@ -75,10 +60,3 @@ def document_to_texts(document):
         speaker_id = speaker_id_u
     texts.append(' '.join(buffer))
     return texts
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/korpus_modu_web.py
+++ b/Korpora/korpus_modu_web.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuWebKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuWebKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_WEB')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_웹_말뭉치.train', load_modu_web(paths))
 

--- a/Korpora/korpus_modu_web.py
+++ b/Korpora/korpus_modu_web.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuWebKorpus(Korpus):
@@ -62,10 +47,3 @@ def load_modu_web(paths):
 
 def document_to_text(document):
     return '\n'.join([p['form'] for p in document['paragraph']])
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/korpus_modu_written.py
+++ b/Korpora/korpus_modu_written.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from glob import glob
 from tqdm import tqdm
 from typing import List
-from Korpora.korpora import Korpus, KorpusData
 
-from .korpus_modu_news import description, license, fetch_modu
+from .korpora import KorpusData
+from .korpus_modu_news import ModuKorpus
+from .utils import default_korpora_path
 
 
-class ModuWrittenKorpus(Korpus):
-    def __init__(self, root_dir_or_paths, force_download=False):
-        super().__init__(description, license)
+class ModuWrittenKorpus(ModuKorpus):
+    def __init__(self, root_dir_or_paths=None, force_download=False):
+        super().__init__()
+        if root_dir_or_paths is None:
+            root_dir_or_paths = os.path.join(default_korpora_path, 'NIKL_WRITTEN')
         paths = find_corpus_paths(root_dir_or_paths)
         self.train = KorpusData('모두의_문어_말뭉치.train', load_modu_written(paths))
 

--- a/Korpora/korpus_modu_written.py
+++ b/Korpora/korpus_modu_written.py
@@ -7,22 +7,7 @@ from tqdm import tqdm
 from typing import List
 from Korpora.korpora import Korpus, KorpusData
 
-
-description = """    모두의 말뭉치는 문화체육관광부 산하 국립국어원에서 제공하는 말뭉치로
-    총 13 개의 말뭉치로 이뤄져 있습니다.
-    해당 말뭉치를 이용하기 위해서는 국립국어원 홈페이지에 가셔서 "회원가입 > 말뭉치 신청 > 승인"의
-    과정을 거치셔야 합니다.
-    https://corpus.korean.go.kr/#none
-    모두의 말뭉치는 승인 후 다운로드 가능 기간 및 횟수 (3회) 에 제한이 있습니다.
-    로그인 기능 및 Korpora 패키지에서의 다운로드 기능을 제공하려 하였지만,
-    국립국어원에서 위의 이유로 이에 대한 기능은 제공이 불가함을 확인하였습니다.
-    Korpora==0.2.0 에서는 "개별 말뭉치 신청 > 승인"이 완료되었다고 가정,
-    로컬에 다운로드 된 말뭉치를 손쉽게 로딩하는 기능만 제공할 예정입니다
-    (Korpora 개발진 lovit@github, ratsgo@github)"""
-
-license = """    모두의 말뭉치의 모든 저작권은 `문화체육관광부 국립국어원
-    (National Institute of Korean Language)` 에 귀속됩니다.
-    정확한 라이센스는 확인 중 입니다."""
+from .korpus_modu_news import description, license, fetch_modu
 
 
 class ModuWrittenKorpus(Korpus):
@@ -62,10 +47,3 @@ def load_modu_written(paths):
 
 def document_to_texts(document):
     return [p['form'] for p in document['paragraph']]
-
-
-def fetch_modu():
-    raise NotImplementedError(
-        "국립국어원에서 API 기능을 제공해 줄 수 없음을 확인하였습니다."
-        "\n이에 따라 모두의 말뭉치는 fetch 기능을 제공하지 않습니다"
-    )

--- a/Korpora/loader.py
+++ b/Korpora/loader.py
@@ -10,6 +10,13 @@ from .korpus_namuwiki import NamuwikiTextKorpus, fetch_namuwikitext
 from .korpus_naverchangwon_ner import NaverChangwonNERKorpus, fetch_naverchangwon_ner
 from .korpus_nsmc import NSMCKorpus, fetch_nsmc
 from .korpus_question_pair import QuestionPairKorpus, fetch_questionpair
+from Korpora.korpus_modu_news import ModuNewsKorpus, fetch_modu
+from Korpora.korpus_modu_messenger import ModuMessengerKorpus
+from Korpora.korpus_modu_morpheme import ModuMorphemeKorpus
+from Korpora.korpus_modu_ne import ModuNEKorpus
+from Korpora.korpus_modu_spoken import ModuSpokenKorpus
+from Korpora.korpus_modu_web import ModuWebKorpus
+from Korpora.korpus_modu_written import ModuWrittenKorpus
 from .utils import default_korpora_path
 
 
@@ -70,6 +77,13 @@ KORPUS = {
     'naver_changwon_ner': NaverChangwonNERKorpus,
     'nsmc': NSMCKorpus,
     'question_pair': QuestionPairKorpus,
+    'modu_news': ModuNewsKorpus,
+    'modu_messenger': ModuMessengerKorpus,
+    'modu_mp': ModuMorphemeKorpus,
+    'modu_ne': ModuNEKorpus,
+    'modu_spoken': ModuSpokenKorpus,
+    'modu_web': ModuWebKorpus,
+    'modu_written': ModuWrittenKorpus,
 }
 
 KORPUS_DESCRIPTION = {
@@ -85,6 +99,13 @@ KORPUS_DESCRIPTION = {
     'naver_changwon_ner': "네이버 + 창원대 NER shared task data",
     'nsmc': "e9t@github 님이 만드신 Naver sentiment movie corpus v1.0",
     'question_pair': "songys@github 님이 만드신 질문쌍(Paired Question v.2)",
+    'modu_news': '국립국어원에서 만든 모두의 말뭉치: 뉴스 말뭉치',
+    'modu_messenger': '국립국어원에서 만든 모두의 말뭉치: 메신저 말뭉치',
+    'modu_mp': '국립국어원에서 만든 모두의 말뭉치: 형태 분석 말뭉치',
+    'modu_ne': '국립국어원에서 만든 모두의 말뭉치: 개체명 분석 말뭉치',
+    'modu_spoken': '국립국어원에서 만든 모두의 말뭉치: 구어 말뭉치',
+    'modu_web': '국립국어원에서 만든 모두의 말뭉치: 웹 말뭉치',
+    'modu_written': '국립국어원에서 만든 모두의 말뭉치: 문어 말뭉치',
 }
 
 FETCH = {
@@ -100,4 +121,11 @@ FETCH = {
     'naver_changwon_ner': fetch_naverchangwon_ner,
     'nsmc': fetch_nsmc,
     'question_pair': fetch_questionpair,
+    'modu_news': fetch_modu,
+    'modu_messenger': fetch_modu,
+    'modu_mp': fetch_modu,
+    'modu_ne': fetch_modu,
+    'modu_spoken': fetch_modu,
+    'modu_web': fetch_modu,
+    'modu_written': fetch_modu,
 }

--- a/Korpora/loader.py
+++ b/Korpora/loader.py
@@ -33,10 +33,6 @@ class Korpora:
         return_single = isinstance(corpus_names, str)
         if return_single:
             corpus_names = [corpus_names]
-
-        if root_dir is None:
-            root_dir = default_korpora_path
-
         corpora = [KORPUS[corpus_name](root_dir, force_download) for corpus_name in corpus_names]
         if return_single:
             return corpora[0]


### PR DESCRIPTION
# Pull Request
Korpora에 기여해 주셔서 감사합니다.

해당 Pull Request를 제출하기 전에 아래 사항이 완료되었는지 확인 부탁드립니다:
- [x] 작성한 코드가 어떤 에러나 경고 없이 실행이 되나요?
- [ ] 작성한 코드에 대한 테스트 코드를 만드셨나요? (경로 : `Korpora/test`)
- [x] 기존 코드 역시 에러 없이 수행이 되겠죠?

## 1. 해당 PR은 어떤 내용인가요?
- 모두의 말뭉치는 `ModuCorpus` 라는 abstract class 를 상속하도록 합니다. 
- 모두의 말뭉치 loader 를 Korpora 의 `load`, `fetch`, `corpus_list` 함수에 추가합니다.

## 2. PR과 관련된 이슈가 있나요?
#118 #128