### PR TITLE
Translated korean_comments.md (#139)

### DIFF
--- a/en-docs/corpuslist/korean_comments.md
+++ b/en-docs/corpuslist/korean_comments.md
@@ -2,23 +2,23 @@
 sort: 2
 ---
 
-# KcBERT 댓글 데이터
+# KcBERT Pre-Training Corpus
 
-KcBERT 댓글 데이터는 beomi@github 님이 공개한 KcBERT 학습데이터입니다.
-데이터 정보는 다음과 같습니다.
+KcBERT Pre-Training Corpus is the training data for KcBERT, Korean comments BERT, released by beomi@github.
+The data specification is as follows:
 
 - author: beomi@github
 - repository: https://github.com/Beomi/KcBERT
 - size:
-  - train: 86,246,285 examples
+- train: 86,246,285 examples
 
-## 1. 파이썬에서 사용하기
+## 1. In Python
 
-파이썬 콘솔을 실행한 뒤 말뭉치를 내려받고 읽어들일 수 있습니다.
+Execute Python console, download the corpus, and read it.
 
-### 말뭉치 다운로드
+### Downloading the corpus
 
-KcBERT 댓글 데이터를 로컬에 내려 받는 파이썬 예제는 다음과 같습니다.
+You can download KcBERT Pre-Training Corpus in the local by the following procedure.
 
 ```python
 from Korpora import Korpora
@@ -26,62 +26,61 @@ Korpora.fetch("kcbert")
 ```
 
 ```note
-기본적으로 사용자의 로컬 컴퓨터 루트 하위의 Korpora라는 디렉토리에 말뭉치를 내려 받습니다(`~/Korpora`). 다른 경로에 말뭉치를 다운로드 받고 싶다면 
-fetch 함수 실행시 `root_dir=custom_path`라는 인자를 추가하세요.
+First, download the corpus to Korpora, a directory under the user's local computer root (`~/Korpora`). If you want to download it in other path, please assign `root_dir=custom_path` when you execute fetch function.
 ```
 
 ```tip
-fetch 함수 실행시 `force_download=True`라는 인자를 줄 경우 해당 말뭉치가 이미 로컬에 있더라도 이를 무시하고 다시 내려 받습니다. 기본값은 `False`입니다.
+If you assign `force_download=True` when you execute the fetch function, the corpus is downloaded again regardless of its presence in the local. The default is `False`.
 ```
 
 
-### 말뭉치 읽어들이기
+### Reading the corpus
 
-KcBERT 댓글 데이터를 파이썬 콘솔에서 읽어들이는 예제는 다음과 같습니다.
-말뭉치가 로컬에 없다면 다운로드도 함께 수행합니다.
+You can read KcBERT Pre-Training Corpus in Python console with the following scheme.
+If the corpus is not in the local, the downloading is accompanied.
 
 ```python
 from Korpora import Korpora
 corpus = Korpora.load("kcbert")
 ```
 
-다음과 같이 실행해도 KcBERT 댓글 데이터를 읽어들일 수 있습니다.
-수행 결과는 위의 코드와 동일합니다.
+You can read KcBERT Pre-Training Corpus as below;
+the result is the same as the above operation.
 
 ```python
 from Korpora import KcBERTKorpus
 corpus = KcBERTKorpus()
 ```
 
-위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
-`train`은 KcBERT 댓글 데이터의 train 데이터로 첫번째 인스턴스는 다음과 같이 확인할 수 있습니다.
+Execute one of the above, and the copus is assigned to the variable `corpus`.
+`train` denotes the train data of KcBERT Pre-Training Corpus, and you can check the first instance as:
+
 
 ```
 >>> corpus.train[0]
 우리에게 북한은 꼭 없애야 할 적일뿐
 ```
 
-`get_all_texts`라는 메소드를 실행하면 KcBERT 댓글 데이터의 모든 text(질문)를 확인할 수 있습니다.
+The method `get_all_texts` lets you check all the texts (news comments) in KcBERT Pre-Training Corpus.
 
 ```
 >>> corpus.get_all_texts()
 ```
 
 
-## 2. 터미널에서 사용하기
+## 2. In terminal
 
-파이썬 콘솔 실행 없이 바로 말뭉치를 다운받을 수 있습니다.
-다음과 같이 실행하면 됩니다.
+You can download the corpus without executing Python console.
+The command is as below.
 
 ```bash
 korpora fetch --corpus kcbert
 ```
 
 ```note
-기본적으로 사용자의 로컬 컴퓨터 루트 하위의 Korpora라는 디렉토리에 말뭉치를 내려 받습니다(`~/Korpora`). 다른 경로에 말뭉치를 다운로드 받고 싶다면 
-터미널에서 fetch 함수 실행시 `--root_dir custom_path`라는 인자를 추가하세요.
+First, download the corpus to Korpora, a directory under the user's local computer root (`~/Korpora`). If you want to download it in other path, please assign `--root_dir custom_path` when you execute fetch function in the terminal.
 ```
 
 ```tip
-터미널에서 fetch 함수 실행시 `--force_download`라는 인자를 줄 경우 해당 말뭉치가 이미 로컬에 있더라도 이를 무시하고 다시 내려 받습니다.
+If you assign `--force_download` when you execute fetch function in the terminal, the corpus is downloaded again regardless of its presence in the local.
 ```

--- a/en-docs/corpuslist/korean_comments.md
+++ b/en-docs/corpuslist/korean_comments.md
@@ -10,7 +10,7 @@ The data specification is as follows:
 - author: beomi@github
 - repository: https://github.com/Beomi/KcBERT
 - size:
-- train: 86,246,285 examples
+  - train: 86,246,285 examples
 
 ## 1. In Python
 


### PR DESCRIPTION
## 1. 해당 PR은 어떤 내용인가요?
#142 에 이어 korean_comments를 번역하였습니다. #141 을 많이 참고하였으며, 구조적인 부분은 앞으로도 비슷한 방식으로 진행될 것 같습니다.

## 2. PR과 관련된 이슈가 있나요?
- Korean news comments data가 직역이긴 하지만, KcBERT Pre-Training Corpus 라는 캐글 배포 이름을 사용하였습니다.
- ko-docs 원문에 text(질문) 으로 되어 있는 부분을 text(뉴스 댓글)로 수정해야 할 것 같습니다. 이 부분은 별도의 PR를 드리도록 하겠습니다.
