### PR TITLE
Unify variable name in Korean Docs (#121)

### DIFF
--- a/ko-docs/corpuslist/aihub_translation.md
+++ b/ko-docs/corpuslist/aihub_translation.md
@@ -68,7 +68,7 @@ corpus = AIHubTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -107,7 +107,7 @@ corpus = AIHubSpokenTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubSpokenTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubSpokenTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -146,7 +146,7 @@ corpus = AIHubConversationTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubSpokenTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubSpokenTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -186,7 +186,7 @@ corpus = AIHubNewsTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubNewsTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubNewsTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -226,7 +226,7 @@ corpus = AIHubKoreanCultureTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubKoreanCultureTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubKoreanCultureTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -266,7 +266,7 @@ corpus = AIHubDecreeTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubDecreeTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubDecreeTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.
@@ -306,7 +306,7 @@ corpus = AIHubGovernmentWebsiteTranslationKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/AIHub_translation` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubGovernmentWebsiteTranslationKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `AIHubGovernmentWebsiteTranslationKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_messenger.md
+++ b/ko-docs/corpuslist/modu_messenger.md
@@ -51,7 +51,7 @@ corpus = ModuMessengerKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 `~/Korpora/NIKL_MESSENGER` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuMessengerKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuMessengerKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_mp.md
+++ b/ko-docs/corpuslist/modu_mp.md
@@ -40,7 +40,7 @@ corpus = ModuMorphemeKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/NIKL_MP` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuMorphemeKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuMorphemeKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_ne.md
+++ b/ko-docs/corpuslist/modu_ne.md
@@ -40,7 +40,7 @@ corpus = ModuNEKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/NIKL_NE` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuNEKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuNEKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_news.md
+++ b/ko-docs/corpuslist/modu_news.md
@@ -54,7 +54,7 @@ corpus = ModuNewsKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 `~/Korpora/NIKL_NEWSPAPER` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuNewsKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuNewsKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 ```tip

--- a/ko-docs/corpuslist/modu_spoken.md
+++ b/ko-docs/corpuslist/modu_spoken.md
@@ -40,7 +40,7 @@ corpus = ModuSpokenKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/NIKL_SPOKEN` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuSpokenKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuSpokenKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_web.md
+++ b/ko-docs/corpuslist/modu_web.md
@@ -40,7 +40,7 @@ corpus = ModuWebKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/NIKL_WEB` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuWebKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuWebKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.

--- a/ko-docs/corpuslist/modu_written.md
+++ b/ko-docs/corpuslist/modu_written.md
@@ -40,7 +40,7 @@ corpus = ModuWrittenKorpus()
 
 ```warning
 위의 코드는 해당 말뭉치가 사용자의 로컬 컴퓨터 루트 하위의 `~/Korpora/NIKL_WRITTEN` 디렉토리에 압축이 해제된 상태로 존재하는 걸 전제로 작동합니다. 
-만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuWrittenKorpus` 클래스 선언시 `root_dir_or_paths=custom_path` 인자를 추가하시기 바랍니다.
+만일 다른 디렉토리에 말뭉치가 존재한다면 `ModuWrittenKorpus` 클래스 선언시 `root_dir=custom_path` 인자를 추가하시기 바랍니다.
 ```
 
 위 코드 둘 중 하나를 택해 실행하면 `corpus`라는 변수에 말뭉치를 로드합니다.


### PR DESCRIPTION
# Pull Request
Korpora에 기여해 주셔서 감사합니다.

해당 Pull Request를 제출하기 전에 아래 사항이 완료되었는지 확인 부탁드립니다:
- [x] 작성한 코드가 어떤 에러나 경고 없이 실행이 되나요?
- [ ] 작성한 코드에 대한 테스트 코드를 만드셨나요? (경로 : `Korpora/test`)
- [x] 기존 코드 역시 에러 없이 수행이 되겠죠?

## 1. 해당 PR은 어떤 내용인가요?
한국어 설명 문서에서 `root_dir_or_paths`라고 표현된 변수명을 `root_dir`로 통일하는 PR입니다.
pages 브랜치에 머지합니다.

## 2. PR과 관련된 이슈가 있나요?
https://github.com/ko-nlp/Korpora/issues/121